### PR TITLE
fix: Add delay before updating authStore

### DIFF
--- a/front-end/src/components/components/Header.js
+++ b/front-end/src/components/components/Header.js
@@ -27,7 +27,9 @@ const Header =()=>{
             if(!body.success) alert(body.message);
             else{
                 navigate('/');
-                setAuth(null, false)
+                setTimeout(() => {
+                    setAuth(null, false);
+                }, 500);
             }
         })
     }

--- a/front-end/src/components/pages/MyProfile.js
+++ b/front-end/src/components/pages/MyProfile.js
@@ -116,7 +116,9 @@ const MyProfile =()=>{
             if(!body.success) alert(body.message);
             else{
                 navigate('/');
-                setAuth(null, false)
+                setTimeout(() => {
+                    setAuth(null, false);
+                }, 500);
             }
         })
     }


### PR DESCRIPTION
Added a timeout function to ensure that the Auth store does not update until the user is redirected to the login page. This prevents the current page from re-rendering when its auth and refresh tokens are gone.